### PR TITLE
Fix: #80 focus-within  class should be applied to focused element

### DIFF
--- a/src/focus-within.js
+++ b/src/focus-within.js
@@ -13,7 +13,7 @@ function polyfill() {
    * @return {Array} computedPath
    */
   function computeEventPath(node) {
-    var path = [];
+    var path = [node];
     var parent = null;
 
     while ((parent = node.parentNode || node.host || node.defaultView)) {


### PR DESCRIPTION
Include the focused or blurred node in the path list so that class is applied or removed to it.